### PR TITLE
Make compatible with OCaml >= 4.05.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-	OCamldot
+# OCamldot
+**(now compatible for OCaml >= 4.05)**
 
-*** What is OCamldot ***
+## What is OCamldot
 OCamldot is a small library to parse and print graphviz dot files.
+
 Graphviz: http://www.graphviz.org
 
-More details on:
-  http://zoggy.github.com/ocamldot
+### More details on:
+http://zoggy.github.com/ocamldot
 
-*** Installation
+### Installation
 See the INSTALL file for the compilation and installation procedure.
 
-*** Author ***
+## Author
 Maxence Guesdon <maxence.guesdon@inria.fr>

--- a/checkocaml.ml
+++ b/checkocaml.ml
@@ -420,7 +420,7 @@ let (<<) v1 v2 =
     | ([], _) -> true
     | (_,[]) -> false
     | (h1::q1, h2::q2) ->
-        (h1 < h2) or
+        (h1 < h2) ||
         (h1 = h2 && (iter (q1,q2)))
   in
   iter (v1,v2)
@@ -822,7 +822,7 @@ let check_ocamlfind_package ?min_version ?max_version ?(fail=true) ?not_found co
             let version = version_of_string s in
             let min = match min_version with None -> [] | Some v -> v in
             let max = match max_version with None -> [max_int] | Some v -> v in
-            if version < min or version > max then
+            if version < min || version > max then
               (
                not_found (`Package_bad_version s);
                false

--- a/odot_lexer.mll
+++ b/odot_lexer.mll
@@ -84,7 +84,7 @@ rule main = parse
     {
       let id = Lexing.lexeme lexbuf in
       try
-	List.assoc (String.lowercase id) keywords
+	List.assoc (String.lowercase_ascii id) keywords
       with
 	Not_found ->
 	  print_DEBUG ("ID "^id);

--- a/odot_parser.mly
+++ b/odot_parser.mly
@@ -31,7 +31,7 @@ let compass_pt_of_id id =
      | Double_quoted_id s -> s
      | Html_id s -> "<"^s^">"
   in
-  let s = String.lowercase s in
+  let s = String.lowercase_ascii s in
   match s with
     "n" -> N
    | "ne" -> NE


### PR DESCRIPTION
- use Bytes for mutable strings
- `String.lowercase` -> `String.lowercase_ascii`
- `or` -> `||`

(unrelatedly)
- Convert README to Markdown